### PR TITLE
Create switch.tradfri.markdown

### DIFF
--- a/source/_components/switch.tradfri.markdown
+++ b/source/_components/switch.tradfri.markdown
@@ -1,0 +1,16 @@
+---
+layout: page
+title: "IKEA Trådfri Switch"
+description: "Access and control your ZigBee-based IKEA Trådfri (Tradfri) Switches."
+date: 2018-09-30 19.22
+sidebar: true
+comments: false
+sharing: true
+footer: true
+logo: ikea.svg
+ha_category: Switch
+ha_iot_class: "Local Polling"
+ha_release: 0.80
+---
+
+For installation instructions, see [the Trådfri component](/components/tradfri/).


### PR DESCRIPTION
**Description:**
This PR adds a documentation page for the IKEA Tradfri Switch component.

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#17007

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follow the [standards][standards].

[standards]: https://home-assistant.io/developers/documentation/standards/
